### PR TITLE
fix: update screenscraper id for ports

### DIFF
--- a/config.json
+++ b/config.json
@@ -605,8 +605,8 @@
       },
       {
         "dir": "PORTS",
-        "id": "137",
-        "name": "PC Win9X",
+        "id": "138",
+        "name": "PC Windows",
         "box": "/mnt/mmc/MUOS/info/catalogue/PORTS/box/",
         "preview": "/mnt/mmc/MUOS/info/catalogue/PORTS/preview/",
         "synopsis": "/mnt/mmc/MUOS/info/catalogue/PORTS/text/"


### PR DESCRIPTION
hi @milouk - thanks for developing this tool! it's working perfectly on muOS Bananas on a RG35XX-SP

I had some trouble scraping Portmaster games until editing my config to this, so thought I'd send the fix back upstream :)

on screenscraper.fr, you can see that the platform with id `137` (Win 9X) has 0 games listed, so will always error when scraping

<img width="325" alt="Screenshot 2024-10-18 at 21 22 13" src="https://github.com/user-attachments/assets/bec88cbc-b130-490b-ab55-d4c328ee91f0">


I think this should be the platform with id `138` (Windows) with 43690 games listed - this commit updates the `id` and `name` for the `PORTS` entry