### PR TITLE
feat: Updates released directory structure & shell file name to match MuOS Pixie conventions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
 
       - name: Bundle App
         run: |
-          mkdir -p .artie && \
-          cp -r ./dist/app ./assets ./config.json .artie
-          zip -r Artie.zip .artie ./Artie\ Scraper.sh
+          mkdir -p .artie Artie && \
+          cp -r ./dist/app ./assets ./config.json .artie && \
+          cp -r ./.artie ./mux_launch.sh ./Artie
+          zip -r Artie.zip ./Artie
 
       - name: Upload assets
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Follow these steps to install Artie:
 
 3. **Configure Artie**:
 
-   In `config.json` ensure:
+   In `Artie/.artie/config.json` ensure:
 
    a) `roms` is correctly configured to the path your roms are located.
 
@@ -41,13 +41,14 @@ Follow these steps to install Artie:
 
 4. **Copy Files to MuOS**:
 
-   - Copy the `.artie` directory and `Artie Scraper.sh` script to `/mnt/mmc/MUOS/application/`.
+   - Copy the `Artie` directory to `/mnt/mmc/MUOS/application/`.
 
    This could be done via CLI with:
 
-   `scp -r .artie/ Artie\ Scraper.sh root@<your IP>:/mnt/mmc/MUOS/application/`
+   `scp -r Artie/ root@<your IP>:/mnt/mmc/MUOS/application/`
 
 5. **Launch Artie Scraper**:
+
    - Open MuOS and launch Artie Scraper from your applications menu.
 
 ## Contributing
@@ -73,6 +74,7 @@ We welcome contributions! Feel free to open issues or submit pull requests (PRs)
    - Implement your changes and commit them with clear and concise messages.
 
 5. **Submit a Pull Request**:
+
    - Push your changes to your fork and submit a pull request to the main repository. Be sure to mention what feature you are implementing or which bug you are fixing.
 
 ### Reporting Bugs

--- a/mux_launch.sh
+++ b/mux_launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo app >/tmp/act_go
 
-ARTIE_DIR="/mnt/mmc/MUOS/application/.artie"
+ARTIE_DIR="/mnt/mmc/MUOS/application/Artie/.artie"
 
 cd "$ARTIE_DIR" || exit
 


### PR DESCRIPTION
I could not easily test the releaser script, though I did a manual test and it seems to work- worth running locally first to make sure my linux code is right. I manually tested this by using the most recent version and adding an "Artie" folder manually, then updating the .sh script like I've done here in this PR.

## Changes

* Updated the zipped folder structure to look like this:
  * Artie/
    * .artie/...
    * mux_launch.sh
* Renamed `Artie Scraper.sh` to `mux_launch.sh` to match other applications in MuOS.
* Updated README.md to reflect changes.

Note: For the app name to be "Artie Scraper" I can change the root release directory name from "Artie" to "Artie Scraper", I wasn't sure what it's supposed to be. The root directory will be the name of the application.